### PR TITLE
docs: replace ASCII architecture diagram with Mermaid

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,38 +4,55 @@ A Samsung SmartThings app that triggers home events (flash lights, toggle switch
 
 ## Architecture
 
-```
-┌──────────────────┐     ┌──────────────────┐     ┌─────────────────────┐
-│  SmartThings App │────▶│  API Gateway      │────▶│  Node.js SmartApp   │
-│  (User's phone)  │     │  (webhook)        │     │  Lambda             │
-└──────────────────┘     └──────────────────┘     └────────┬────────────┘
-                                                           │
-                                                           ▼
-                                                  ┌─────────────────────┐
-                                                  │  DynamoDB            │
-                                                  │  - installations     │
-                                                  │  - match_state       │
-                                                  │  - active_fixtures   │
-                                                  └───┬────────────┬────┘
-                                                      ▲            ▲
-                                                      │            │
-┌──────────────┐  ┌──────────────────┐  ┌─────────────┴──┐  ┌─────┴───────────┐
-│  ESPN API    │◀─│  CloudWatch      │─▶│  Fixture        │  │  Goal Poller    │
-│  (scoreboard │  │  Events          │  │  Checker Lambda │  │  Lambda         │
-│   + summary) │  │  (15min / 60s)   │  │  (Python)       │  │  (Python)       │
-└──────────────┘  └──────────────────┘  └────────┬────────┘  └────────┬────────┘
-                                                 │                    │
-                                                 │ enables/disables   ▼
-                                                 │ goal poller rule   ┌─────────────┐
-                                                 └───────────────────▶│ SmartThings │
-                                                                      │ REST API    │
-                                                                      └─────────────┘
+```mermaid
+flowchart LR
+    phone["📱 SmartThings App\n(user's phone)"]
+
+    subgraph aws ["AWS"]
+        direction LR
+        apigw["API Gateway"]
+        smartapp["SmartApp Lambda\n(Node.js)"]
+
+        subgraph timers ["CloudWatch Events"]
+            cw15["15 min\n(always on)"]
+            cw60["60s\n(toggled)"]
+        end
+
+        subgraph lambdas ["Lambda Functions"]
+            fixture["Fixture Checker\nLambda (Python)"]
+            poller["Goal Poller\nLambda (Python)"]
+        end
+
+        subgraph ddb ["DynamoDB"]
+            db_inst[("installations")]
+            db_fixtures[("active_fixtures")]
+            db_state[("match_state")]
+        end
+    end
+
+    espn["🌐 ESPN API"]
+    stapi["📡 SmartThings\nREST API"]
+
+    phone -- "lifecycle events" --> apigw --> smartapp
+    smartapp -- "store config" --> db_inst
+
+    cw15 --> fixture
+    fixture -- "read/write" --> db_fixtures
+    fixture -. "enable/disable" .-> cw60
+    fixture --> espn
+
+    cw60 --> poller
+    poller --> espn
+    poller -- "read/write" --> db_state
+    poller -- "read" --> db_fixtures
+    poller -- "read" --> db_inst
+    poller -- "flash lights/\ntoggle switches" --> stapi
 ```
 
 ### Two-Poller Design
 
-- **Fixture Checker** (every 15 min, always on) — discovers upcoming/live matches for tracked teams
-- **Goal Poller** (every 60s, starts disabled) — only runs during live matches to detect goals and trigger SmartThings devices
+- **Fixture Checker** (every 15 min, always on) — discovers upcoming/live matches for tracked teams and enables the Goal Poller rule when a match is live
+- **Goal Poller** (every 60s, toggled) — only runs during live matches to detect score changes and trigger SmartThings devices
 - This avoids constant polling when no games are on
 
 ## Competitions Covered
@@ -53,7 +70,7 @@ A Samsung SmartThings app that triggers home events (flash lights, toggle switch
 ## Prerequisites
 
 - **Python 3.14+** with [uv](https://docs.astral.sh/uv/)
-- **Node.js 22+** with npm
+- **Node.js LTS** with npm
 - **AWS CLI** configured with credentials
 - **AWS CDK** (`npm install -g aws-cdk`)
 - **Samsung SmartThings Developer Account** — [developer.smartthings.com](https://developer.smartthings.com/)
@@ -77,9 +94,9 @@ cd smartapp && npm install && cd ..
 
 1. Go to [developer.smartthings.com](https://developer.smartthings.com/) → **New Project** → **Automation for the SmartThings App**
 2. Select **WebHook Endpoint** as the hosting type
-3. After deploying (step 4), paste the API Gateway URL as the webhook endpoint
+3. After deploying (step 3 below), paste the API Gateway URL as the webhook endpoint
 4. Under **App Display Name**, set a name like "Goal Watcher"
-5. Under **Permissions**, add: `r:devices:*`, `x:devices:*` (read and execute device commands)
+5. Under **Permissions**, add: `r:devices:*`, `x:devices:*`
 6. Save and note the **App ID** and **Client ID/Secret**
 
 ### 3. Deploy to AWS
@@ -99,7 +116,7 @@ The deploy will output:
 ### 4. Install the SmartApp on your phone
 
 1. Open the **SmartThings app** on your phone
-2. Go to **Menu** → **SmartApps** → **+** → Find your app
+2. Go to **Menu** → **SmartApps** → **+** → find your app
 3. Select your Scottish football team
 4. Choose lights/switches to trigger on goals
 5. Select which competitions to monitor
@@ -107,19 +124,22 @@ The deploy will output:
 ## Development
 
 ```bash
-# Run tests
+# Python: run tests
 uv run pytest
 
-# Lint
-uv run ruff check .
+# Python: lint + format
+uv run ruff check . && uv run ruff format .
 
-# Type check
+# Python: type check
 uv run mypy app/ tests/
 
-# Format
-uv run ruff format .
+# Node.js: run tests
+cd smartapp && npm test
 
-# CDK synth (validate stack)
+# Node.js: lint
+cd smartapp && npm run lint
+
+# CDK: validate stack
 cdk synth
 ```
 
@@ -130,11 +150,16 @@ app/
   app.py                              # CDK app entrypoint
   goal_watcher/
     cdk/                              # CDK stack definition
-    fixture_checker/                  # Fixture discovery Lambda
-    goal_poller/                      # Goal detection + notification Lambda
+    fixture_checker/                  # Fixture discovery Lambda (Python)
+    goal_poller/                      # Goal detection + notification Lambda (Python)
     model/                            # Pydantic models
     shared/                           # ESPN client, DynamoDB helpers, constants
-smartapp/                             # Node.js SmartThings SmartApp
+smartapp/                             # Node.js SmartThings SmartApp Lambda
+  src/
+    index.js                          # Lambda handler
+    smartapp.js                       # SmartApp config pages
+    dynamodb-context-store.js         # DynamoDB context store adapter
+    teams.js                          # 42 Scottish teams with ESPN IDs
 tests/
   unit/                               # Unit tests (network disabled)
   integration/                        # Integration tests (network enabled)
@@ -142,10 +167,11 @@ tests/
 
 ## How It Works
 
-1. **User installs SmartApp** → selects team (e.g., St Johnstone) + devices (lights, switches) + competitions
-2. **Fixture Checker** runs every 15 minutes → polls ESPN for all Scottish competitions → finds matches involving St Johnstone → stores in DynamoDB → enables Goal Poller
+1. **User installs SmartApp** → selects team (e.g., St Johnstone) + devices (lights, switches) + competitions → stored in DynamoDB
+2. **Fixture Checker** runs every 15 minutes → polls ESPN for all Scottish competitions → finds matches involving the tracked team → stores active fixtures in DynamoDB → enables Goal Poller
 3. **Goal Poller** runs every 60 seconds during live matches → compares current score vs stored state → detects new goals → fetches scorer details from ESPN match summary
-4. **On goal detected** → reads SmartApp installations → sends commands to SmartThings REST API → lights flash, switches toggle
+4. **On goal detected** → reads SmartApp installations from DynamoDB → sends commands to SmartThings REST API → lights flash, switches toggle
+5. **When match ends** → Fixture Checker disables the Goal Poller rule until the next match day
 
 ## ESPN API
 

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -46,6 +46,7 @@ words:
   - taplo
   # Common abbreviations
   - vars
+  - stapi
   - addopts
   - Airdrieonians
   - Alloa


### PR DESCRIPTION
## Summary

Replaces the ASCII art architecture diagram with a Mermaid flowchart that GitHub renders natively. Also updates several sections to reflect the current state of the project.

## Changes

### `README.md`
- **Architecture diagram** — replaced ASCII art with a `mermaid` code block (LR flowchart) showing all components with labelled edges: SmartThings app, API Gateway, SmartApp Lambda, Fixture Checker Lambda, Goal Poller Lambda, CloudWatch Events rules, DynamoDB tables, ESPN API, SmartThings REST API
- **Two-Poller Design** — clarified that Fixture Checker enables *and* disables the Goal Poller rule
- **Prerequisites** — updated Node.js version from `22+` to `LTS`
- **Development commands** — added Node.js `npm test` and `npm run lint` commands
- **Project structure** — expanded `smartapp/src/` to show individual files
- **How It Works** — added step 5 (Fixture Checker disables Goal Poller when match ends)

### `cspell.config.yaml`
- Added `stapi` (Mermaid node ID used in the README code block)

## Testing

Documentation-only change. Pre-commit hooks (cspell, yamllint, yamlfmt) all pass.
