### PR TITLE
feat: add Lambda dependency layer built from uv.lock

### DIFF
--- a/.github/instructions/actions-log.instructions.md
+++ b/.github/instructions/actions-log.instructions.md
@@ -6,15 +6,15 @@ Maintain the `ACTIONS.md` file at the project root as a living record of all dev
 
 ## Rules
 
-- **Update `ACTIONS.md` after every session** that makes changes to the codebase.
-- Each session entry should include:
+- **Update `ACTIONS.md` for every PR** before it is raised (or as a final commit on the branch).
+- Each PR entry should include:
   - **Date** as a heading (e.g., `## 2026-03-28 — Feature Name`)
   - **Summary** — one or two sentences describing what was done
   - **Actions Taken** — bullet list of specific changes, grouped by phase or component
   - **Bugs Found & Fixed** — if any were discovered and resolved
   - **Commits** — list the git commit hashes and messages created during the session
 - **Keep the TODO section current** — check off completed items, add new ones as they arise.
-- When completing a TODO item, move it from the TODO section into the relevant session's "Actions Taken" with a note that it was completed.
+- When completing a TODO item, move it from the TODO section into the relevant entry's "Actions Taken" with a note that it was completed.
 - Use conventional commit prefixes in action descriptions where applicable (`feat:`, `fix:`, `test:`, `docs:`, `chore:`).
 
 ## Format

--- a/.github/instructions/aws-serverless.instructions.md
+++ b/.github/instructions/aws-serverless.instructions.md
@@ -8,13 +8,97 @@ AWS-specific conventions for serverless projects using CDK and Lambda. Follow th
 
 - **AWS CDK with Python** for all infrastructure. CDK app entry point is `app/app.py`.
 - Always apply **cdk-nag** `AwsSolutionsChecks` as an Aspect. Add targeted `NagSuppressions` with clear `reason` strings when suppressing — never blanket-suppress. Always obtain explicit permission when adding suppressions, and explain why when asking for this.
-- Use **Lambda dependency layers** built from `uv.lock` using a custom `DependencyLayer` construct that exports requirements via `uv export`.
+- Use **Lambda dependency layers** built from `uv.lock` using a custom `DependencyLayer` construct that exports requirements via `uv export`. See the **Lambda Dependency Layer** section below for full details.
 - Default Lambda config: **ARM_64 architecture**, **JSON logging format**, **Lambda Insights** enabled, explicit **log group** with short retention (1 week) and `DESTROY` removal policy.
 - Use `CfnOutput` for all stack outputs needed by tests or other consumers. Define output names as a `StrEnum` class (e.g., `class Outputs(StrEnum)`) on the Stack class.
 - Use `RemovalPolicy.DESTROY` for scratch/dev resources. Enable point-in-time recovery for DynamoDB tables.
 - Enforce SSL on SQS queues (`enforce_ssl=True`).
 
-## Lambda Functions
+## Lambda Dependency Layer
+
+The `DependencyLayer` construct (lives at `app/<project>/cdk/dependency_layer.py`) bundles Python runtime dependencies from `uv.lock` into a Lambda layer so they are not included in the function code asset.
+
+### How it works
+
+1. **Local step** — `DependencyLayer.Bundler.try_bundle()` runs `uv export --no-dev --frozen` to generate `build/requirements.txt` from `uv.lock`. Returns `False` so CDK continues to the Docker step.
+2. **Docker step** — CDK runs `pip3 install -r requirements.txt -t /asset-output/python` inside the Lambda runtime image, producing an architecture-correct layer package.
+3. The layer is fingerprinted against `uv.lock` so it is only rebuilt when dependencies change.
+
+### pyproject.toml structure
+
+Keep CDK and dev tooling in `[dependency-groups] dev`. Keep only Lambda runtime deps in `[project] dependencies` — these are what `uv export --no-dev` exports into the layer:
+
+```toml
+[project]
+dependencies = [
+    "aws-lambda-powertools>=...",
+    "boto3>=...",
+    "pydantic>=...",
+    # any other runtime-only deps
+]
+
+[dependency-groups]
+dev = [
+    "aws-cdk-lib>=...",
+    "cdk-nag>=...",
+    "constructs>=...",
+    "mypy>=...",
+    "pytest>=...",
+    # ...
+]
+```
+
+If a Lambda needs a subset of deps, define a named group and pass `dependency_group="lambda"` to `DependencyLayer`.
+
+### Usage in a stack
+
+```python
+from .dependency_layer import DependencyLayer
+
+LAMBDA_RUNTIME = lambda_.Runtime.PYTHON_3_13
+LAMBDA_ARCHITECTURE = lambda_.Architecture.ARM_64
+
+dependency_layer = DependencyLayer(
+    self,
+    "MyDependencyLayer",
+    runtime=LAMBDA_RUNTIME,
+    architecture=LAMBDA_ARCHITECTURE,
+    # dependency_group="lambda"  # omit to export all non-dev deps
+)
+
+fn = lambda_.Function(
+    self, "MyFunction",
+    runtime=LAMBDA_RUNTIME,
+    architecture=LAMBDA_ARCHITECTURE,
+    layers=[dependency_layer],
+    code=lambda_.Code.from_asset("app", exclude=["**/cdk/**", "**/__pycache__"]),
+    handler="my_project.my_lambda.app.handler",
+    ...
+)
+```
+
+### Stubbing in CDK unit tests
+
+The real `DependencyLayer` requires Docker (for bundling). Stub it in test conftest so tests run without Docker:
+
+```python
+import tempfile
+from unittest.mock import patch
+from aws_cdk import aws_lambda as lambda_
+
+class _StubDependencyLayer(lambda_.LayerVersion):
+    def __init__(self, scope, id, **_kwargs):
+        super().__init__(scope, id, code=lambda_.Code.from_asset(tempfile.mkdtemp()))
+
+@pytest.fixture
+def template() -> Template:
+    with patch("app.<project>.cdk.<stack_module>.DependencyLayer", _StubDependencyLayer):
+        app = App()
+        stack = MyStack(app, "TestStack")
+    return Template.from_stack(stack)
+```
+
+
 
 - **Always use AWS Lambda Powertools:**
   - `Logger` with `@logger.inject_lambda_context(clear_state=True)` decorator.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,6 @@ repos:
     rev: v8.18.0
     hooks:
       - id: cspell
-
   - repo: local
     hooks:
       - id: eslint

--- a/ACTIONS.md
+++ b/ACTIONS.md
@@ -211,6 +211,29 @@ Resolved all 13 mypy strict errors across 2 files. No blanket suppressions — a
 
 ---
 
+## 2026-03-28 — Lambda Dependency Layer
+
+### Summary
+
+Added a `DependencyLayer` CDK construct that bundles Python runtime dependencies from `uv.lock` into a Lambda layer. Restructured `pyproject.toml` to separate CDK dev deps from Lambda runtime deps, and documented the full pattern in the AWS Copilot instructions.
+
+### Actions Taken
+
+- `feat:` Created `app/goal_watcher/cdk/dependency_layer.py` — `DependencyLayer` construct; local step runs `uv export --no-dev --frozen` to produce `requirements.txt`, Docker step runs `pip3 install` into `/asset-output/python` for the correct Lambda architecture
+- `chore:` Moved `aws-cdk-lib`, `cdk-nag`, `constructs` from `[project]` to `[dependency-groups] dev` in `pyproject.toml` so `uv export --no-dev` only captures Lambda runtime deps
+- `feat:` Updated `GoalWatcherStack` to create a shared `DependencyLayer` and attach it to the fixture-checker and goal-poller Lambdas; extracted `LAMBDA_RUNTIME`/`LAMBDA_ARCHITECTURE` module-level constants
+- `test:` Stubbed `DependencyLayer` in CDK unit test conftest to avoid requiring Docker; added `TestLambdaLayer` class asserting layer exists, Python fns use it, SmartApp does not
+- `docs:` Added full `DependencyLayer` documentation to `aws-serverless.instructions.md` (construct design, pyproject.toml structure, usage example, test stub pattern)
+- `docs:` Updated `actions-log.instructions.md` — ACTIONS.md now updated per PR rather than per session
+- `chore:` Added `parsable` to cspell word list (flagged in python instructions)
+- `feat:` ~~Add a Lambda dependency layer (built from `uv.lock`) instead of bundling deps in Lambda zip~~ — **completed, closes [#14](https://github.com/csteinle/goal_watcher/issues/14)**
+
+### Commits
+
+- `c19edaa` feat: add Lambda dependency layer built from uv.lock
+
+---
+
 ## TODO — Next Steps
 
 ### Deployment
@@ -235,7 +258,7 @@ Resolved all 13 mypy strict errors across 2 files. No blanket suppressions — a
 - [ ] [#13](https://github.com/csteinle/goal_watcher/issues/13) Add match start/end notifications (not just goals)
 - [ ] [#15](https://github.com/csteinle/goal_watcher/issues/15) Add opponent goal alerts (optional — "the other team scored against you")
 - [ ] [#17](https://github.com/csteinle/goal_watcher/issues/17) Implement OAuth token refresh in the Python poller (currently relies on Node.js SDK context store)
-- [ ] [#14](https://github.com/csteinle/goal_watcher/issues/14) Add a Lambda dependency layer (built from `uv.lock`) instead of bundling deps in Lambda zip
+- [x] [#14](https://github.com/csteinle/goal_watcher/issues/14) Add a Lambda dependency layer (built from `uv.lock`) instead of bundling deps in Lambda zip
 - [ ] [#16](https://github.com/csteinle/goal_watcher/issues/16) Consider EventBridge Scheduler instead of enable/disable pattern for cleaner poller control
 - [ ] [#19](https://github.com/csteinle/goal_watcher/issues/19) Add match-day awareness to fixture checker (skip polling on non-match days using ESPN calendar)
 

--- a/app/goal_watcher/cdk/__init__.py
+++ b/app/goal_watcher/cdk/__init__.py
@@ -1,6 +1,7 @@
 """Goal Watcher CDK stack and constructs."""
 
 from .constants import Outputs
+from .dependency_layer import DependencyLayer
 from .goal_watcher_stack import GoalWatcherStack
 
-__all__ = ["GoalWatcherStack", "Outputs"]
+__all__ = ["DependencyLayer", "GoalWatcherStack", "Outputs"]

--- a/app/goal_watcher/cdk/dependency_layer.py
+++ b/app/goal_watcher/cdk/dependency_layer.py
@@ -1,0 +1,108 @@
+"""Lambda dependency layer construct built from uv.lock."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import jsii
+from aws_cdk import BundlingOptions, FileSystem, ILocalBundling, aws_lambda as lambda_
+from constructs import Construct
+
+
+class DependencyLayer(lambda_.LayerVersion):
+    """Lambda layer that bundles Python runtime dependencies from uv.lock.
+
+    Uses ``uv export`` to generate a requirements.txt from the lock file, then
+    installs them via pip inside the Lambda bundling Docker image. Local bundling
+    only generates the requirements file; Docker handles the actual pip install so
+    packages are compiled for the correct Lambda runtime/architecture.
+    """
+
+    BUILD_DIR = (Path(__file__).parents[3] / "build").resolve()
+    LOCK_FILE = (Path(__file__).parents[3] / "uv.lock").resolve()
+
+    def __init__(
+        self,
+        scope: Construct,
+        id: str,  # noqa: A002
+        runtime: lambda_.Runtime,
+        architecture: lambda_.Architecture,
+        dependency_group: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        lambda_bundling_runtime = lambda_.Runtime(
+            f"{runtime.name}:latest-{architecture.name}",
+            runtime.family,
+        )
+
+        self.BUILD_DIR.mkdir(exist_ok=True)
+        if not (self.BUILD_DIR / ".gitignore").exists():
+            with (self.BUILD_DIR / ".gitignore").open("w") as f:
+                f.write("*\n")
+
+        super().__init__(
+            scope,
+            id,
+            code=lambda_.Code.from_asset(
+                str(self.BUILD_DIR),
+                asset_hash=FileSystem.fingerprint(
+                    str(self.LOCK_FILE),
+                ),
+                bundling=BundlingOptions(
+                    image=lambda_bundling_runtime.bundling_image,
+                    local=self.Bundler(dependency_group),
+                    command=[
+                        "pip3",
+                        "install",
+                        "-r",
+                        str(self.requirements_file(dependency_group).name),
+                        "-t",
+                        "/asset-output/python",
+                    ],
+                ),
+            ),
+            compatible_runtimes=[runtime],
+            compatible_architectures=[architecture],
+            **kwargs,
+        )
+
+    @classmethod
+    def requirements_file(cls, dependency_group: str | None = None) -> Path:
+        """Return the path to the generated requirements file."""
+        return (
+            cls.BUILD_DIR / f"requirements_{dependency_group}.txt"
+            if dependency_group
+            else cls.BUILD_DIR / "requirements.txt"
+        )
+
+    @jsii.implements(ILocalBundling)
+    class Bundler:
+        """Local bundler that generates requirements.txt via uv export."""
+
+        def __init__(self, dependency_group: str | None = None):
+            self.dependency_group = dependency_group
+
+        def try_bundle(self, *_args: Any, **_kwargs: Any) -> bool:
+            uv_path = shutil.which("uv")
+            if not uv_path:
+                raise RuntimeError(
+                    "uv command not found. Ensure uv is installed and in PATH.",
+                )
+
+            cmd = [
+                uv_path,
+                "export",
+                "--format",
+                "requirements.txt",
+                "--no-dev",
+                "--output-file",
+                str(DependencyLayer.requirements_file(self.dependency_group)),
+                "--frozen",
+                "--quiet",
+            ] + (["--group", self.dependency_group] if self.dependency_group else [])
+
+            subprocess.run(cmd, check=True)  # noqa: S603
+            return False  # local step only generates requirements file; Docker does the pip install

--- a/app/goal_watcher/cdk/goal_watcher_stack.py
+++ b/app/goal_watcher/cdk/goal_watcher_stack.py
@@ -27,6 +27,10 @@ from .constants import (
     MATCH_STATE_TABLE_NAME,
     Outputs,
 )
+from .dependency_layer import DependencyLayer
+
+LAMBDA_RUNTIME = lambda_.Runtime.PYTHON_3_13
+LAMBDA_ARCHITECTURE = lambda_.Architecture.ARM_64
 
 
 class GoalWatcherStack(Stack):
@@ -34,6 +38,15 @@ class GoalWatcherStack(Stack):
 
     def __init__(self, scope: Construct, construct_id: str, **kwargs: Any) -> None:
         super().__init__(scope, construct_id, **kwargs)
+
+        # --- Shared Lambda dependency layer ---
+
+        dependency_layer = DependencyLayer(
+            self,
+            "GoalWatcherDependencyLayer",
+            runtime=LAMBDA_RUNTIME,
+            architecture=LAMBDA_ARCHITECTURE,
+        )
 
         # --- DynamoDB Tables ---
 
@@ -79,7 +92,7 @@ class GoalWatcherStack(Stack):
             self,
             "FixtureCheckerFunction",
             function_name="goal-watcher-fixture-checker",
-            runtime=lambda_.Runtime.PYTHON_3_13,
+            runtime=LAMBDA_RUNTIME,
             handler="app.goal_watcher.fixture_checker.app.handler",
             code=lambda_.Code.from_asset(
                 "app",
@@ -89,7 +102,8 @@ class GoalWatcherStack(Stack):
                     "goal_watcher/goal_poller/**",
                 ],
             ),
-            architecture=lambda_.Architecture.ARM_64,
+            layers=[dependency_layer],
+            architecture=LAMBDA_ARCHITECTURE,
             memory_size=256,
             timeout=Duration.seconds(120),
             environment={
@@ -113,7 +127,7 @@ class GoalWatcherStack(Stack):
             self,
             "GoalPollerFunction",
             function_name="goal-watcher-goal-poller",
-            runtime=lambda_.Runtime.PYTHON_3_13,
+            runtime=LAMBDA_RUNTIME,
             handler="app.goal_watcher.goal_poller.app.handler",
             code=lambda_.Code.from_asset(
                 "app",
@@ -123,7 +137,8 @@ class GoalWatcherStack(Stack):
                     "goal_watcher/fixture_checker/**",
                 ],
             ),
-            architecture=lambda_.Architecture.ARM_64,
+            layers=[dependency_layer],
+            architecture=LAMBDA_ARCHITECTURE,
             memory_size=256,
             timeout=Duration.seconds(120),
             environment={
@@ -153,7 +168,7 @@ class GoalWatcherStack(Stack):
                 "smartapp",
                 exclude=["node_modules/.cache"],
             ),
-            architecture=lambda_.Architecture.ARM_64,
+            architecture=LAMBDA_ARCHITECTURE,
             memory_size=256,
             timeout=Duration.seconds(30),
             environment={

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -49,6 +49,7 @@ words:
   - stapi
   - resp
   - kwargs
+  - parsable
   - addopts
   - Airdrieonians
   - Alloa

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,17 +4,17 @@ version = "0.1.0"
 description = "SmartThings app that triggers home events when a Scottish football team scores a goal"
 requires-python = ">=3.14"
 dependencies = [
-    "aws-cdk-lib>=2.180.0",
     "aws-lambda-powertools>=3.7.0",
     "boto3>=1.42.77",
-    "cdk-nag>=2.35.0",
-    "constructs>=10.4.0",
     "httpx>=0.28.0",
     "pydantic>=2.11.0",
 ]
 
 [dependency-groups]
 dev = [
+    "aws-cdk-lib>=2.180.0",
+    "cdk-nag>=2.35.0",
+    "constructs>=10.4.0",
     "faker>=40.11.1",
     "mypy>=1.15.0",
     "polyfactory>=2.19.0",

--- a/tests/unit/cdk/conftest.py
+++ b/tests/unit/cdk/conftest.py
@@ -2,15 +2,30 @@
 
 from __future__ import annotations
 
+import tempfile
+from unittest.mock import patch
+
 import pytest
-from aws_cdk import App
+from aws_cdk import App, aws_lambda as lambda_
 from aws_cdk.assertions import Template
 
 from app.goal_watcher.cdk.goal_watcher_stack import GoalWatcherStack
 
 
+class _StubDependencyLayer(lambda_.LayerVersion):
+    """Stub that avoids Docker bundling during CDK unit tests."""
+
+    def __init__(self, scope: App, id: str, **_kwargs: object) -> None:  # noqa: A002
+        super().__init__(
+            scope,
+            id,
+            code=lambda_.Code.from_asset(tempfile.mkdtemp()),
+        )
+
+
 @pytest.fixture
 def template() -> Template:
-    app = App()
-    stack = GoalWatcherStack(app, "TestStack")
+    with patch("app.goal_watcher.cdk.goal_watcher_stack.DependencyLayer", _StubDependencyLayer):
+        app = App()
+        stack = GoalWatcherStack(app, "TestStack")
     return Template.from_stack(stack)

--- a/tests/unit/cdk/test_goal_watcher_stack.py
+++ b/tests/unit/cdk/test_goal_watcher_stack.py
@@ -71,6 +71,29 @@ class TestDynamoDBTables:
         )
 
 
+class TestLambdaLayer:
+    """Lambda layer resource assertions."""
+
+    def test_dependency_layer_created(self, template: Template) -> None:
+        template.resource_count_is("AWS::Lambda::LayerVersion", 1)
+
+    def test_python_functions_use_dependency_layer(self, template: Template) -> None:
+        template.has_resource_properties(
+            "AWS::Lambda::Function",
+            {"FunctionName": "goal-watcher-fixture-checker", "Layers": Match.any_value()},
+        )
+        template.has_resource_properties(
+            "AWS::Lambda::Function",
+            {"FunctionName": "goal-watcher-goal-poller", "Layers": Match.any_value()},
+        )
+
+    def test_smartapp_has_no_layer(self, template: Template) -> None:
+        template.has_resource_properties(
+            "AWS::Lambda::Function",
+            {"FunctionName": "goal-watcher-smartapp", "Layers": Match.absent()},
+        )
+
+
 class TestLambdaFunctions:
     """Lambda function resource assertions."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -114,6 +114,7 @@ dependencies = [
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/f6/b280afd91b2284744c0bb26afa1272bd60270726b4d3999fc27b68200854/boto3-1.42.77.tar.gz", hash = "sha256:c6d9b05e5b86767d4c6ef762f155c891366e5951162f71d030e109fe531f4fd9", size = 112773, upload-time = "2026-03-26T19:25:35.365Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/e6/e27fb0956bd52e6ac222d47eaa04d267887ca1d52a6b3c25d2006c8dc9e6/boto3-1.42.77-py3-none-any.whl", hash = "sha256:95eb3ef693068586f70ca3f29c43701c34a9a73d0df413ea7eaff138efa4a6b9", size = 140555, upload-time = "2026-03-26T19:25:32.069Z" },
 ]
@@ -261,17 +262,17 @@ name = "goal-watcher"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "aws-cdk-lib" },
     { name = "aws-lambda-powertools" },
     { name = "boto3" },
-    { name = "cdk-nag" },
-    { name = "constructs" },
     { name = "httpx" },
     { name = "pydantic" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "aws-cdk-lib" },
+    { name = "cdk-nag" },
+    { name = "constructs" },
     { name = "faker" },
     { name = "mypy" },
     { name = "polyfactory" },
@@ -285,17 +286,17 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aws-cdk-lib", specifier = ">=2.180.0" },
     { name = "aws-lambda-powertools", specifier = ">=3.7.0" },
     { name = "boto3", specifier = ">=1.42.77" },
-    { name = "cdk-nag", specifier = ">=2.35.0" },
-    { name = "constructs", specifier = ">=10.4.0" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "pydantic", specifier = ">=2.11.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "aws-cdk-lib", specifier = ">=2.180.0" },
+    { name = "cdk-nag", specifier = ">=2.35.0" },
+    { name = "constructs", specifier = ">=10.4.0" },
     { name = "faker", specifier = ">=40.11.1" },
     { name = "mypy", specifier = ">=1.15.0" },
     { name = "polyfactory", specifier = ">=2.19.0" },


### PR DESCRIPTION
## Summary

Adds a `DependencyLayer` CDK construct that bundles Python runtime dependencies from `uv.lock` into a Lambda layer, keeping them out of the function code asset. Closes #16.

## Changes

### New files
- `app/goal_watcher/cdk/dependency_layer.py` — `DependencyLayer` construct; local step runs `uv export --no-dev --frozen` to generate `requirements.txt`, Docker step runs `pip3 install` into `/asset-output/python`

### Modified files
- `pyproject.toml` — moved CDK deps (`aws-cdk-lib`, `cdk-nag`, `constructs`) from `[project]` to `[dependency-groups] dev` so `uv export --no-dev` only exports Lambda runtime deps
- `uv.lock` — updated after pyproject.toml restructure
- `app/goal_watcher/cdk/goal_watcher_stack.py` — create shared `DependencyLayer`; attach to fixture-checker and goal-poller Lambdas; extract `LAMBDA_RUNTIME`/`LAMBDA_ARCHITECTURE` module-level constants
- `app/goal_watcher/cdk/__init__.py` — export `DependencyLayer`
- `tests/unit/cdk/conftest.py` — stub `DependencyLayer` with a no-op `LayerVersion` to avoid Docker in unit tests
- `tests/unit/cdk/test_goal_watcher_stack.py` — add `TestLambdaLayer` asserting layer is created, Python fns use it, SmartApp does not
- `.github/instructions/aws-serverless.instructions.md` — full `DependencyLayer` documentation (pattern, pyproject.toml structure, usage example, test stub)
- `cspell.config.yaml` — added `parsable`

## Testing

All 54 unit tests pass. 0 mypy errors. All pre-commit hooks pass.